### PR TITLE
Rewrote list-complete-demo in transitions.md to include v-move, fixes #1704

### DIFF
--- a/src/v2/guide/transitions.md
+++ b/src/v2/guide/transitions.md
@@ -1174,7 +1174,6 @@ new Vue({
 
 ``` css
 .list-complete-item {
-  transition: all 1s;
   display: inline-block;
   margin-right: 10px;
 }
@@ -1183,8 +1182,14 @@ new Vue({
   opacity: 0;
   transform: translateY(30px);
 }
+.list-complete-enter-active, .list-complete-leave-active {
+  transition: all 1s;
+}
 .list-complete-leave-active {
   position: absolute;
+}
+.list-complete-move {
+  transition: transform 1s;
 }
 ```
 
@@ -1225,7 +1230,6 @@ new Vue({
 </script>
 <style>
 .list-complete-item {
-  transition: all 1s;
   display: inline-block;
   margin-right: 10px;
 }
@@ -1233,8 +1237,14 @@ new Vue({
   opacity: 0;
   transform: translateY(30px);
 }
+.list-complete-enter-active, .list-complete-leave-active {
+  transition: all 1s;
+}
 .list-complete-leave-active {
   position: absolute;
+}
+.list-complete-move {
+  transition: transform 1s;
 }
 </style>
 {% endraw %}

--- a/src/v2/guide/unit-testing.md
+++ b/src/v2/guide/unit-testing.md
@@ -71,7 +71,7 @@ describe('MyComponent', () => {
 
 ## Writing Testable Components
 
-A component's render output is primarily determined by the props they receive. If a component's render output solely depends on its props it becomes straightforward to test, similar to asserting the return value of a pure function with different arguments. Take a simplified example:
+A component's render output is primarily determined by the props it receives. If a component's render output solely depends on its props it becomes straightforward to test, similar to asserting the return value of a pure function with different arguments. Take a simplified example:
 
 ``` html
 <template>


### PR DESCRIPTION
This PR fixes the `list-complete-demo` in transitions.md. The demo is supposed to demonstrate how `v-move` can be used to solve a problem with a previous demo `list-demo`, where adding or removing a list item causes the ones around it to instantly snap into their new place instead of smoothly transitioning. It actually goes on to solve the problem without employing `v-move` at all as described in #1704.