### PR TITLE
Replacing avatar.io to unavatar.now.sh

### DIFF
--- a/src/v2/guide/team.md
+++ b/src/v2/guide/team.md
@@ -15,7 +15,7 @@ order: 803
         :src="'https://github.com/' + profile.github + '.png'"
         :alt="profile.name" width=80 height=80>
       <img v-else-if="profile.twitter"
-        :src="'https://avatars.io/twitter/' + profile.twitter"
+        :src="'https://unavatar.now.sh/twitter/' + profile.twitter"
         :alt="profile.name" width=80 height=80>
     </div>
     <div class="profile">


### PR DESCRIPTION
Since avatars.io is not available anymore, some avatars are broken.

<img width="485" alt="Screenshot 2020-07-23 at 07 41 35" src="https://user-images.githubusercontent.com/1155694/88279039-c8512a80-ccb9-11ea-9e4c-8fbd84533d8a.png">


This PR proposes to replace the avatar service to a new that [they recommend](https://shkspr.mobi/blog/2020/07/goodbye-avatars-io-hello-unavatar/) 