### PR TITLE
fix(html): add canonical tag

### DIFF
--- a/themes/vue/layout/layout.ejs
+++ b/themes/vue/layout/layout.ejs
@@ -18,6 +18,8 @@
     <link rel="alternate" hreflang="fr" href="https://fr.vuejs.org/<%- page.path %>">
     <link rel="alternate" hreflang="es" href="https://es.vuejs.org/<%- page.path %>">
 
+    <link rel="canonical" href="/<%- page.path %>" />
+
     <meta property="og:type" content="article">
     <meta property="og:title" content="<%- page.title ? page.title + ' — ' : '' %>Vue.js">
     <meta property="og:description" content="<%- theme.site_description %>">


### PR DESCRIPTION
Hello,

Those pages are accessible through different urls but not properly deduplicated for search engine / crawler.
Google succeed at deduplicating but not [others](https://www.bing.com/search?q=site%3Afr.vuejs.org+Conventions+instreamset%3Aurl%3Aindex.html&qs=n&form=QBRE&sp=-1&pq=site%3Afr.vuejs.org+conventions+instreamset%3Aurl%3Aindex.html&sc=0-56&sk=&cvid=7153C0CDAE184F8099AEB609686F1387)

https://vuejs.org/v2/guide/ ->
https://vuejs.org/v2/guide/index.html 

https://vuejs.org/v2/cookbook/ ->
https://vuejs.org/v2/cookbook/index.html 

https://vuejs.org/v2/api/ ->
https://vuejs.org/v2/api/index.html 

https://vuejs.org/v2/style-guide/ ->
https://vuejs.org/v2/style-guide/index.html

[... more]

--- 

It only impact robots and will not redirect user. 
Good other solutions would be:
- choose one and stop serving the other path
- 301 for one or the other path


