### PR TITLE
docs: Include reactive property deletion

### DIFF
--- a/src/v2/guide/reactivity.md
+++ b/src/v2/guide/reactivity.md
@@ -57,6 +57,12 @@ Sometimes you may want to assign a number of properties to an existing object, f
 this.someObject = Object.assign({}, this.someObject, { a: 1, b: 2 })
 ```
 
+Similarly, it is also possible to delete object properties in a manner detectable by vue using the `Vue.delete(object, propertyName)` method:
+
+``` js
+Vue.delete(vm.someObject, 'b')
+```
+
 ### For Arrays
 
 Vue cannot detect the following changes to an array:


### PR DESCRIPTION
Added section on Vue-detectable object property deletion. Formerly only methods for reactive object key addition were present.

Information regarding this reactivity found on the following page -
https://vuejs.org/v2/api/?#Vue-delete

Note
====
This repository is for Vue 1.x and 2.x only. Issues and pull requests related to 3.x are managed in the v3 doc repo: https://github.com/vuejs/docs-next.
