### PR TITLE
Add Sakai and Atlantis themes for PrimeVue

### DIFF
--- a/themes/vue/source/js/theme-data.js
+++ b/themes/vue/source/js/theme-data.js
@@ -145,6 +145,20 @@ var themeData = [
     seeMoreUrl: 'https://www.primefaces.org/primevue/#/?af_id=4218',
     products: [
       {
+        name: 'Sakai',
+        price: 0,
+        description: 'Free Admin Template',
+        url: 'https://www.primefaces.org/sakai-vue/#/?af_id=4218',
+        image: 'https://www.primefaces.org/vue-templates/sakai.jpg'
+      },
+      {
+        name: 'Atlantis',
+        price: 59,
+        description: 'Premium Admin Template',
+        url: 'https://www.primefaces.org/layouts/atlantis-vue?af_id=4218',
+        image: 'https://www.primefaces.org/vue-templates/atlantis.jpg'
+      },
+      {
         name: 'Freya',
         price: 59,
         description: 'Premium Admin Template',
@@ -152,18 +166,18 @@ var themeData = [
         image: 'https://www.primefaces.org/vue-templates/freya.jpg'
       },
       {
-        name: 'Diamond',
-        price: 59,
-        description: 'PrimeOne Design Admin Template',
-        url: 'https://www.primefaces.org/layouts/diamond-vue?af_id=4218',
-        image: 'https://www.primefaces.org/vue-templates/diamond.jpg'
-      },
-      {
         name: 'Ultima',
         price: 79,
         description: 'Material Design Admin Template',
         url: 'https://www.primefaces.org/layouts/ultima-vue?af_id=4218',
         image: 'https://www.primefaces.org/vue-templates/ultima.jpg'
+      },
+      {
+        name: 'Diamond',
+        price: 59,
+        description: 'PrimeOne Design Admin Template',
+        url: 'https://www.primefaces.org/layouts/diamond-vue?af_id=4218',
+        image: 'https://www.primefaces.org/vue-templates/diamond.jpg'
       },
       {
         name: 'Sapphire',
@@ -213,13 +227,6 @@ var themeData = [
         description: 'Highly Customizable Admin Template',
         url: 'https://www.primefaces.org/layouts/prestige-vue?af_id=4218',
         image: 'https://www.primefaces.org/vue-templates/prestige.jpg'
-      },
-      {
-        name: 'Sigma',
-        price: 0,
-        description: 'Free Admin Template',
-        url: 'https://www.primefaces.org/sigma-vue/#/?af_id=4218',
-        image: 'https://www.primefaces.org/vue-templates/sigma.jpg'
       }
     ]
   },


### PR DESCRIPTION
Adds new Sakai (Free) and Atlantis themes from PrimeVue, moves Ultima before Diamond.