### PR TITLE
Modify the type attribute of launch.json to paw-chrome

### DIFF
--- a/src/v2/cookbook/debugging-in-vscode.md
+++ b/src/v2/cookbook/debugging-in-vscode.md
@@ -52,7 +52,7 @@ Click on the Debugging icon in the Activity Bar to bring up the Debug view, then
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "chrome",
+      "type": "pwa-chrome",
       "request": "launch",
       "name": "vuejs: chrome",
       "url": "http://localhost:8080",


### PR DESCRIPTION
Note
====
This repository is for Vue 1.x and 2.x only. Issues and pull requests related to 3.x are managed in the v3 doc repo: https://github.com/vuejs/docs-next.
