### PR TITLE
Mention vue.config.js runtimeCompiler option

### DIFF
--- a/src/v2/guide/installation.md
+++ b/src/v2/guide/installation.md
@@ -131,7 +131,7 @@ new Vue({
 
 When using `vue-loader` or `vueify`, templates inside `*.vue` files are pre-compiled into JavaScript at build time. You don't really need the compiler in the final bundle, and can therefore use the runtime-only build.
 
-Since the runtime-only builds are roughly 30% lighter-weight than their full-build counterparts, you should use it whenever you can. If you still wish to use the full build instead, you need to configure an alias in your bundler:
+Since the runtime-only builds are roughly 30% lighter-weight than their full-build counterparts, you should use it whenever you can. If you still wish to use the full build instead, you need to configure an alias in your bundler or [set the appropriate config flag](https://cli.vuejs.org/config/#runtimecompiler):
 
 #### Webpack
 


### PR DESCRIPTION
When using vue cli to set up a project setting this flag in the `vue.config.js` config file seems to be the way to include the runtimeCompiler — this was missing from the docs.

Note
====
This repository is for Vue 1.x and 2.x only. Issues and pull requests related to 3.x are managed in the v3 doc repo: https://github.com/vuejs/docs-next.
