### PR TITLE
Update events.md

### DIFF
--- a/src/v2/guide/events.md
+++ b/src/v2/guide/events.md
@@ -178,6 +178,12 @@ To address this problem, Vue provides **event modifiers** for `v-on`. Recall tha
 - `.passive`
 
 ``` html
+Please note that with the exception of `.once` the modifiers above only work with **native events**.
+
+<p class="tip">
+When emitting native-looking events from components, such as 'click', it is a good practice to also emit the native event. eg. `this.$emit('click', {...data, ...event})`. If you haven't read about components yet, don't worry about this for now.
+</p>
+
 <!-- the click event's propagation will be stopped -->
 <a v-on:click.stop="doThis"></a>
 


### PR DESCRIPTION
Added more explanation to modifiers that require a native event, otherwise generating surprising error messages. 

(People get caught in this, eg. https://github.com/mirari/vue-fullscreen/issues/22 
When I got caught, I could find many threads online related to trying to use native modifiers without a native event and I didn't find a sound answer other than novices blaming Vue for this and experts not being able to reproduce the problem.)

Note
====
This repository is for Vue 1.x and 2.x only. Issues and pull requests related to 3.x are managed in the v3 doc repo: https://github.com/vuejs/docs-next.
