### PR TITLE
Added code for importing base components with Vite

### DIFF
--- a/src/v2/style-guide/index.md
+++ b/src/v2/style-guide/index.md
@@ -786,6 +786,18 @@ Some advantages of this convention:
     Vue.component(baseComponentName, baseComponentConfig)
   })
   ```
+- With Vite:
+    ``` js
+  const baseComponents = import.meta.glob("./src/Base[A-Z]\w+\.(vue|js)$/");
+  for (const path in baseComponents) {
+    const component = await baseComponents[path]();
+    const baseComponentConfig = component.default || component;
+    const baseComponentName =
+      baseComponentConfig.name || path.replace(/^.+\//, "").replace(/\.\w+$/, "");
+
+    Vue.component(baseComponentName, baseComponentConfig);
+  }
+  ```
 
 {% raw %}</details>{% endraw %}
 


### PR DESCRIPTION
The latest boilerplate uses Vite instead of webpack and many tutorials used the code in this page to import multiple base components but that only worked with webpack, so I included the code that worked with Vite. 
Reference: https://vitejs.dev/guide/features.html#glob-import

Note
====
This repository is for Vue 1.x and 2.x only. Issues and pull requests related to 3.x are managed in the v3 doc repo: https://github.com/vuejs/docs-next.
