### PR TITLE
Update Vue School banner copy

### DIFF
--- a/themes/vue/layout/partials/vueschool_banner.ejs
+++ b/themes/vue/layout/partials/vueschool_banner.ejs
@@ -8,10 +8,10 @@
   <div class="vs-core">
     <div class="vs-slogan">
       <div class="vs-slogan-up">
-        Get up to <strong>40% off</strong> your Vue School Subscription
+        Extended for <strong>48 hours!</strong>
       </div>
       <div class="vs-slogan-down">
-        Time Limited Offer
+        Get up to 40% off your Vue School Subscription
       </div>
     </div>
     <div class="vs-button">

--- a/themes/vue/source/css/_vueschool.styl
+++ b/themes/vue/source/css/_vueschool.styl
@@ -71,6 +71,7 @@ body.has-vs-banner
   @media (min-width: 680px)
     min-height: $vs-banner-height-desktop
     background-image: url(../images/banners/vs-fw-bg.svg)
+    background-position: top right -130px
   @media (min-width: 900px)
     background-position: top right
     position: static
@@ -116,12 +117,10 @@ body.has-vs-banner
         color: #FFF
         font-size: 14px
         font-weight: bold
-        width: 170px
         @media (min-width: 680px)
           font-size: 18px
-          width: 220px
-        @media (min-width: 1024px)
           width: auto
+        @media (min-width: 1024px)
           font-size: 24px
         strong
           color: #fdc722

--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -285,8 +285,10 @@
    * Banner closing
    */
   function initVueSchoolBanner () {
+    const now = new Date()
+    const end = new Date('2022-05-04T00:00:00+02:00')
     const banner = document.getElementById('vs')
-    if (banner && !localStorage.getItem('VS_FW_BANNER_CLOSED_2')) {
+    if (banner && (now < end) && !localStorage.getItem('VS_FW_BANNER_CLOSED_2')) {
       banner.classList.remove('vs-hidden')
       document.body.classList.add('has-vs-banner')
       document.getElementById('vs-close').addEventListener('click', function (e) {


### PR DESCRIPTION
This PR updates the text of the Vue School top banner to announce the promo is extended for 48 hs.

Please merge this on `2022-05-01T00:00:00+02:00` (so, on the first minute of Sunday, or soon later).

The banner will stop appearing automatically on `2022-05-04T00:00:00+02:00`, the date is hard-coded.

[Click here to see screenshots of the banner](https://imgur.com/a/a0U6j2C)