### PR TITLE
Remove Vue School banner

### DIFF
--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -3,7 +3,6 @@
   initMobileMenu()
   initVideoModal()
   initNewNavLinks()
-  initVueSchoolBanner()
   if (PAGE_TYPE) {
     initVersionSelect()
     initApiSpecLinks()


### PR DESCRIPTION
This PR removes the Vue School offer banner introduced in https://github.com/vuejs/v2.vuejs.org/pull/2939
