### PR TITLE
Fix special sponsors display

### DIFF
--- a/themes/vue/_config.yml
+++ b/themes/vue/_config.yml
@@ -169,7 +169,7 @@ silver:
     img: localazy.png
   - name: AddWeb Solution
     url: http://addwebsolution.com/
-    img: addweb_solution.png
+    img: addweb_solution.png?v2
   - name: 1394TA
     url: https://1394ta.org
     img: 1394ta.png

--- a/themes/vue/layout/index.ejs
+++ b/themes/vue/layout/index.ejs
@@ -1,3 +1,5 @@
+<% function logo(img) { return `https://sponsors.vuejs.org/images/${img}` } %>
+
 <main role="main">
   <div class="sidebar">
     <div class="sidebar-inner-index">
@@ -29,12 +31,12 @@
     </div>
   </div>
 
-  <%_ if (theme.special_sponsors) { _%>
+  <%_ if (theme.special) { _%>
   <div id="special">
     <h3>Special Sponsor</h3>
-    <% var specialSponsor = theme.special_sponsors[0]; %>
+    <% var specialSponsor = theme.special[0]; %>
     <a href="<%- specialSponsor.url %>" target="_blank" rel="noopener sponsored">
-      <img src="<%- url_for(`/images/${specialSponsor.img}`) %>" style="width:160px" alt="Special sponsor <%- specialSponsor.name %>">
+      <img src="<%- logo(specialSponsor.img) %>" style="width:160px" alt="Special sponsor <%- specialSponsor.name %>">
       <br>
       <!-- <span><%- specialSponsor.description %></span> -->
     </a>

--- a/themes/vue/layout/partials/sponsors_sidebar.ejs
+++ b/themes/vue/layout/partials/sponsors_sidebar.ejs
@@ -1,11 +1,13 @@
-<%_ if (theme.special_sponsors) { _%>
+<% function logo(img) { return `https://sponsors.vuejs.org/images/${img}` } %>
+
+<%_ if (theme.special) { _%>
 <div id="sidebar-sponsors-special">
   <div class="main-sponsor">
     <span>Special Sponsor</span>
     <div>
-    <%_ for (const sponsor of theme.special_sponsors) {_%>
+    <%_ for (const sponsor of theme.special) {_%>
     <a href="<%- sponsor.url %>" target="_blank" rel="sponsored noopener" class="logo">
-      <img src="<%- url_for(`/images/${sponsor.wide_img || sponsor.img}`) %>" alt="<%-sponsor.name-%>">
+      <img src="<%- logo(sponsor.img) %>" alt="<%-sponsor.name-%>">
     </a>
     <%_ } _%>
     </div>


### PR DESCRIPTION
After updating the data format of sponsors, some variable names weren't updated accordingly, which led somewhere the (actually special) sponsors not displaying.

I just fixed it by updating the variable names accordingly.

Thanks.

BTW, the data in `themes/vue/_config.yml` was just auto-updated.

----

Before

![image](https://user-images.githubusercontent.com/206848/178561718-719dbcb3-fe7b-4d69-ad8a-e145c360d8e0.png)

After

![image](https://user-images.githubusercontent.com/206848/178562445-773ccf51-3863-48f0-bfef-24782f2a2f6e.png)

----

Before

![image](https://user-images.githubusercontent.com/206848/178562005-8d980d87-59ac-4bb3-a5a2-8eaf87900ea8.png)

After

![image](https://user-images.githubusercontent.com/206848/178562065-cd84d882-ceec-4004-9d14-74d1faa6218c.png)
