### PR TITLE
Fix a grammatical issue in docs for Components

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -222,7 +222,7 @@ At the very least, you'll want to include the post's content:
 <div v-html="content"></div>
 ```
 
-If you try this in your template however, Vue will show an error, explaining that **every component must have a single root element**. You can fix this error by wrapping the template in a parent element, such as:
+If you try this in your template, however, Vue will show an error, explaining that **every component must have a single root element**. You can fix this error by wrapping the template in a parent element, such as:
 
 ```html
 <div class="blog-post">


### PR DESCRIPTION
`however` needs a comma before it as well. 

Just like line 181 of the same markdown file:

https://github.com/vuejs/v2.vuejs.org/blob/9f5f7472bd6f132ff873652de5256e4000ae2d81/src/v2/guide/components.md?plain=1#L181

See https://prowritingaid.com/comma-however#:~:text=If%20you%20use,was%20another%20story.
and https://www.grammar-monster.com/punctuation/commas_and_however.html

