### PR TITLE
update broken link to VeeValidate

### DIFF
--- a/src/v2/cookbook/form-validation.md
+++ b/src/v2/cookbook/form-validation.md
@@ -437,4 +437,4 @@ We start off with a variable representing the URL of the API that is running on 
 While this cookbook entry focused on doing form validation "by hand", there are, of course, some great Vue libraries that will handle a lot of this for you. Switching to a prepackage library may impact the final size of your application, but the benefits could be tremendous. You have code that is (most likely) heavily tested and also updated on a regular basis. Some examples of form validation libraries for Vue include:
 
 * [vuelidate](https://github.com/monterail/vuelidate)
-* [VeeValidate](https://logaretm.github.io/vee-validate/)
+* [VeeValidate](https://vee-validate.logaretm.com/v3/)


### PR DESCRIPTION
Updated broken link to VeeValidate. Linking to v3 since it's the last version with Vue 2 support.