### PR TITLE
Mark `reactive transform` as deprecated

### DIFF
--- a/src/v2/guide/migration-vue-2-7.md
+++ b/src/v2/guide/migration-vue-2-7.md
@@ -61,7 +61,7 @@ In addition, the following features are explicitly **NOT** ported:
 - ❌ `createApp()` (Vue 2 doesn't have isolated app scope)
 - ❌ Top-level `await` in `<script setup>` (Vue 2 does not support async component initialization)
 - ❌ TypeScript syntax in template expressions (incompatible w/ Vue 2 parser)
-- ❌ Reactivity transform (still experimental)
+- ❌ Reactivity transform (deprecated)
 - ❌ `expose` option is not supported for options components (but `defineExpose()` is supported in `<script setup>`).
 
 ## Upgrade Guide


### PR DESCRIPTION
Note
====
This repository is for Vue 1.x and 2.x only. Issues and pull requests related to 3.x are managed in the v3 doc repo: https://github.com/vuejs/docs-next.
