### PR TITLE
Update components-registration.md

### DIFF
--- a/src/v2/guide/components-registration.md
+++ b/src/v2/guide/components-registration.md
@@ -229,4 +229,4 @@ requireComponent.keys().forEach(fileName => {
 })
 ```
 
-Remember that **global registration must take place before the root Vue instance is created (with `new Vue`)**. [Here's an example](https://github.com/chrisvfritz/vue-enterprise-boilerplate/blob/master/src/components/_globals.js) of this pattern in a real project context.
+Remember that **global registration must take place before the root Vue instance is created (with `new Vue`)**. [Here's an example](https://github.com/bencodezen/vue-enterprise-boilerplate/blob/vue-2-version/src/components/_globals.js) of this pattern in a real project context.


### PR DESCRIPTION
changed example link of global registration to v2 branch, as link doesnt work when pointed at master branch

Note
====
This repository is for Vue 1.x and 2.x only. Issues and pull requests related to 3.x are managed in the v3 doc repo: https://github.com/vuejs/docs-next.
